### PR TITLE
MANTA-4901 - Have cueball manatee primary resolver use version of zookeeper client without reconnect logic

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,7 +15,7 @@ serde_json = "1.0.40"
 slog = { version = "2.4.1", features = [ "max_level_trace" ] }
 slog-stdlog = "3"
 tokio = "0.1.22"
-tokio-zookeeper = { git = 'https://github.com/joyent/tokio-zookeeper', branch = "temp-fix"}
+tokio-zookeeper = { git = 'https://github.com/joyent/tokio-zookeeper', tag = "v0.1.0"}
 url = "2.1.0"
 
 [dev-dependencies]


### PR DESCRIPTION
I cut a release of our tokio-zookeeper fork that does not have the reconnect logic.

See ticket for testing notes.