### PR TITLE
MANTA-4630: update repo and cueball depedency versions.

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -5,7 +5,7 @@ authors = ["Kelly McLaughlin <kelly.mclaughlin@joyent.com>", "Isaac Davis <isaac
 edition = "2018"
 
 [dependencies]
-cueball = { git = 'https://github.com/joyent/rust-cueball', tag = 'v0.2.1' }
+cueball = { git = 'https://github.com/joyent/rust-cueball', branch = 'MANTA-4630' }
 itertools = "0.8.0"
 failure = "0.1.5"
 futures = "0.1.28"
@@ -16,6 +16,7 @@ slog = { version = "2.4.1", features = [ "max_level_trace" ] }
 slog-stdlog = "3"
 tokio = "0.1.22"
 tokio-zookeeper = { git = 'https://github.com/joyent/tokio-zookeeper', branch = "temp-fix"}
+unicode-normalization = "=0.1.5"
 url = "2.1.0"
 
 [dev-dependencies]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,11 +1,11 @@
 [package]
 name = "cueball-manatee-primary-resolver"
-version = "0.1.0"
+version = "0.3.0"
 authors = ["Kelly McLaughlin <kelly.mclaughlin@joyent.com>", "Isaac Davis <isaac.davis@joyent.com>"]
 edition = "2018"
 
 [dependencies]
-cueball = { git = 'https://github.com/joyent/rust-cueball', branch = 'MANTA-4630' }
+cueball = { git = 'https://github.com/joyent/rust-cueball', tag = 'v0.3.0' }
 itertools = "0.8.0"
 failure = "0.1.5"
 futures = "0.1.28"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -5,7 +5,7 @@ authors = ["Kelly McLaughlin <kelly.mclaughlin@joyent.com>", "Isaac Davis <isaac
 edition = "2018"
 
 [dependencies]
-cueball = { git = 'https://github.com/joyent/rust-cueball', tag = 'v0.2.1' }
+cueball = { git = 'https://github.com/joyent/rust-cueball', branch = 'MANTA-4630' }
 itertools = "0.8.0"
 failure = "0.1.5"
 futures = "0.1.28"
@@ -16,6 +16,7 @@ slog = { version = "2.4.1", features = [ "max_level_trace" ] }
 slog-stdlog = "3"
 tokio = "0.1.22"
 tokio-zookeeper = { git = 'https://github.com/joyent/tokio-zookeeper', tag = "v0.1.0"}
+unicode-normalization = "=0.1.5"
 url = "2.1.0"
 
 [dev-dependencies]


### PR DESCRIPTION
Relate rust-cueball PR:

https://github.com/joyent/rust-cueball/pull/17 